### PR TITLE
Update spork for target_env musl compiling

### DIFF
--- a/src/darwin.rs
+++ b/src/darwin.rs
@@ -18,33 +18,6 @@ use super::*;
 use utils;
 use utils::CpuTime;
 
-fn empty_rusage() -> rusage {
-    libc::rusage {
-        ru_utime: timeval {
-            tv_sec: 0,
-            tv_usec: 0,
-        },
-        ru_stime: timeval {
-            tv_sec: 0,
-            tv_usec: 0,
-        },
-        ru_maxrss: 0,
-        ru_ixrss: 0,
-        ru_idrss: 0,
-        ru_isrss: 0,
-        ru_minflt: 0,
-        ru_majflt: 0,
-        ru_nswap: 0,
-        ru_inblock: 0,
-        ru_oublock: 0,
-        ru_msgsnd: 0,
-        ru_msgrcv: 0,
-        ru_nsignals: 0,
-        ru_nvcsw: 0,
-        ru_nivcsw: 0,
-    }
-}
-
 fn map_posix_resp(code: i32) -> Result<i32, SporkError> {
     match code {
         EFAULT => Err(SporkError::new_borrowed(
@@ -157,7 +130,7 @@ pub fn get_stats(kind: &StatType) -> Result<rusage, SporkError> {
     };
 
 
-    let mut usage = empty_rusage();
+    let mut usage = unsafe { std::mem::MaybeUninit::zeroed().assume_init() };
     if let Some(r_code) = code {
         let _ = try!(map_posix_resp(
             unsafe { libc::getrusage(r_code, &mut usage) }
@@ -264,12 +237,6 @@ mod tests {
         let cpu = timespec_to_cpu_time(&times);
         assert_eq!(times.tv_sec as u64, cpu.sec);
         assert_eq!(times.tv_nsec as u64, cpu.usec * 1000);
-    }
-
-    #[test]
-    fn should_get_empty_rusage() {
-        let usage = empty_rusage();
-        assert_eq!(usage.ru_maxrss, 0);
     }
 
     #[test]

--- a/src/darwin.rs
+++ b/src/darwin.rs
@@ -1,21 +1,23 @@
-use mach::task_info::{task_basic_info, task_basic_info_t, task_events_info, task_events_info_t,
-                      task_thread_times_info, task_thread_times_info_t, MIG_ARRAY_TOO_LARGE, TASK_BASIC_INFO,
-                      TASK_BASIC_INFO_COUNT, TASK_EVENTS_INFO, TASK_EVENTS_INFO_COUNT, TASK_THREAD_TIMES_INFO,
-                      TASK_THREAD_TIMES_INFO_COUNT};
 use mach::task::task_info;
-use mach::kern_return::{KERN_INVALID_ARGUMENT, KERN_SUCCESS};
-use mach::traps::mach_task_self;
+use mach::task_info::{
+    task_basic_info, task_basic_info_t, task_thread_times_info, task_thread_times_info_t, MIG_ARRAY_TOO_LARGE,
+    TASK_BASIC_INFO, TASK_BASIC_INFO_COUNT, TASK_THREAD_TIMES_INFO, TASK_THREAD_TIMES_INFO_COUNT,
+};
+
 use mach::time_value::{time_value_add, time_value_t};
 
+use mach::traps::mach_task_self;
+
+use mach::kern_return::{KERN_INVALID_ARGUMENT, KERN_SUCCESS};
+
 use libc;
-use libc::{EFAULT, EINVAL, EPERM, RUSAGE_CHILDREN, RUSAGE_SELF};
+use libc::rusage;
 use libc::timespec;
 use libc::timeval;
-use libc::rusage;
+use libc::{EFAULT, EINVAL, EPERM, RUSAGE_CHILDREN, RUSAGE_SELF};
 
 use super::*;
 
-use utils;
 use utils::CpuTime;
 
 fn map_posix_resp(code: i32) -> Result<i32, SporkError> {
@@ -87,15 +89,8 @@ pub fn get_rusage_from_mach(usage: &mut rusage) -> Result<i32, SporkError> {
     let mut basic_info = task_basic_info::new();
     let basic_info_ptr = (&mut basic_info as task_basic_info_t) as libc::uintptr_t;
     let mut count = TASK_BASIC_INFO_COUNT;
-    try!(map_mach_resp(unsafe {
-        task_info(
-            mach_task_self(),
-            TASK_BASIC_INFO,
-            basic_info_ptr,
-            &mut count,
-        )
-    }));
 
+    map_mach_resp(unsafe { task_info(mach_task_self(), TASK_BASIC_INFO, basic_info_ptr, &mut count) })?;
     usage.ru_maxrss = basic_info.resident_size as i64 / 1024;
     usage.ru_stime = time_value_t_to_timeval(&basic_info.system_time);
 
@@ -107,14 +102,14 @@ pub fn get_thread_cpu_time() -> Result<timespec, SporkError> {
     let mut thread_times = task_thread_times_info::new();
     let thread_times_ptr = (&mut thread_times as task_thread_times_info_t) as libc::uintptr_t;
     let mut thread_times_count = TASK_THREAD_TIMES_INFO_COUNT;
-    let _ = try!(map_mach_resp(unsafe {
+    let _ = map_mach_resp(unsafe {
         task_info(
             mach_task_self(),
             TASK_THREAD_TIMES_INFO,
             thread_times_ptr,
             &mut thread_times_count,
         )
-    }));
+    })?;
 
     // Appears the Linux equivilent to this actually is a compination of CPU and USER times
     // Ok(time_value_t_to_timespec(&(thread_times.user_time)))
@@ -126,17 +121,14 @@ pub fn get_stats(kind: &StatType) -> Result<rusage, SporkError> {
     let (t_times, code): (Option<timespec>, Option<i32>) = match *kind {
         StatType::Process => (None, Some(RUSAGE_SELF)),
         StatType::Children => (None, Some(RUSAGE_CHILDREN)),
-        StatType::Thread => (Some(try!(get_thread_cpu_time())), None),
+        StatType::Thread => (Some(get_thread_cpu_time()?), None),
     };
-
 
     let mut usage = unsafe { std::mem::MaybeUninit::zeroed().assume_init() };
     if let Some(r_code) = code {
-        let _ = try!(map_posix_resp(
-            unsafe { libc::getrusage(r_code, &mut usage) }
-        ));
+        let _ = map_posix_resp(unsafe { libc::getrusage(r_code, &mut usage) })?;
     } else {
-        let _ = try!(get_rusage_from_mach(&mut usage));
+        let _ = get_rusage_from_mach(&mut usage)?;
     }
 
     if t_times.is_some() {
@@ -175,11 +167,7 @@ mod tests {
     }
 
     fn format_timeval(val: &timeval) -> String {
-        format!(
-            "timeval {{ tv_sec: {:?}, tv_usec: {:?} }}",
-            val.tv_sec,
-            val.tv_usec
-        )
+        format!("timeval {{ tv_sec: {:?}, tv_usec: {:?} }}", val.tv_sec, val.tv_usec)
     }
 
     #[allow(dead_code)]
@@ -277,5 +265,4 @@ mod tests {
         assert!(times.tv_sec >= 0);
         assert!(times.tv_nsec >= 0);
     }
-
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,14 +1,13 @@
-
-use sys_info;
 use chrono::UTC;
+use sys_info;
 use thread_id;
 
 use libc::timespec;
 
-use std::collections::HashMap;
-use std::cell::RefCell;
-use std::ops::{Deref, DerefMut};
 use std::borrow::BorrowMut;
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::ops::{Deref, DerefMut};
 
 use super::*;
 
@@ -48,19 +47,19 @@ impl History {
         match *kind {
             StatType::Process => {
                 let mut process = self.process.borrow_mut();
-                let mut process_ref = process.deref_mut();
+                let process_ref = process.deref_mut();
 
                 *process_ref = Some(poll);
             }
             StatType::Thread => {
                 let mut threads = self.thread.borrow_mut();
-                let mut threads_ref = threads.borrow_mut();
+                let threads_ref = threads.borrow_mut();
 
                 threads_ref.insert(get_thread_id(), poll);
             }
             StatType::Children => {
                 let mut children = self.children.borrow_mut();
-                let mut children_ref = children.borrow_mut();
+                let children_ref = children.borrow_mut();
 
                 children_ref.insert(get_thread_id(), poll);
             }
@@ -95,19 +94,19 @@ impl History {
         match *kind {
             StatType::Process => {
                 let mut process = self.process.borrow_mut();
-                let mut process_ref = process.deref_mut();
+                let process_ref = process.deref_mut();
 
                 *process_ref = None;
             }
             StatType::Thread => {
                 let mut threads = self.thread.borrow_mut();
-                let mut threads_ref = threads.borrow_mut();
+                let threads_ref = threads.borrow_mut();
 
                 threads_ref.remove(&get_thread_id());
             }
             StatType::Children => {
                 let mut children = self.children.borrow_mut();
-                let mut children_ref = children.borrow_mut();
+                let children_ref = children.borrow_mut();
 
                 children_ref.remove(&get_thread_id());
             }
@@ -136,7 +135,7 @@ pub fn now_ms() -> i64 {
 }
 
 pub fn get_platform() -> Result<Platform, SporkError> {
-    match try!(sys_info::os_type()).as_ref() {
+    match sys_info::os_type()?.as_ref() {
         "Linux" => Ok(Platform::Linux),
         "Windows" => Ok(Platform::Windows),
         "Darwin" => Ok(Platform::MacOS),
@@ -170,12 +169,8 @@ pub fn get_num_cores() -> Result<usize, SporkError> {
 // Not actually dead - but cargo thinks it is (Used in tests)
 #[allow(dead_code)]
 pub fn empty_timespec() -> timespec {
-    timespec {
-        tv_sec: 0,
-        tv_nsec: 0,
-    }
+    timespec { tv_sec: 0, tv_nsec: 0 }
 }
-
 
 // ---------------------------
 
@@ -409,5 +404,4 @@ mod tests {
         let now = now_ms();
         assert!(now > 0);
     }
-
 }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,14 +1,12 @@
-
 use std;
 
-use winapi;
 use kernel32;
+use winapi;
 use winapi::psapi::PROCESS_MEMORY_COUNTERS;
 
 use utils::CpuTime;
 
 use super::*;
-
 
 fn get_thread_handle() -> winapi::HANDLE {
     unsafe { kernel32::GetCurrentThread() }
@@ -46,7 +44,6 @@ fn wtf(f: winapi::minwindef::FILETIME) -> u64 {
 }
 
 pub fn get_mem_stats(kind: &StatType) -> Result<PROCESS_MEMORY_COUNTERS, SporkError> {
-
     match *kind {
         StatType::Process => {
             let handle = get_current_process();
@@ -86,7 +83,6 @@ pub struct WindowsCpuStats {
 }
 
 pub fn get_cpu_times(kind: &StatType) -> Result<WindowsCpuStats, SporkError> {
-
     match *kind {
         StatType::Process => {
             let handle = get_current_process();
@@ -141,9 +137,7 @@ pub fn get_cpu_times(kind: &StatType) -> Result<WindowsCpuStats, SporkError> {
             "Windows child thread memory stat not yet implemented!".to_owned(),
         )),
     }
-
 }
-
 
 pub fn combine_cpu_times(val: &WindowsCpuStats) -> f64 {
     // Kernal/User time here are in 100ns units. Divide by 10,000,000 to convert
@@ -200,12 +194,10 @@ mod tests {
         let usage = get_cpu_times(&kind);
         match usage {
             Ok(_) => panic!("Should of returned spork error"),
-            Err(err) => {
-                match err.kind {
-                    SporkErrorKind::Unimplemented => assert!(true),
-                    _ => panic!("Wrong error returnd from child process stats failure")
-                }
-            }
+            Err(err) => match err.kind {
+                SporkErrorKind::Unimplemented => assert!(true),
+                _ => panic!("Wrong error returnd from child process stats failure"),
+            },
         }
     }
 
@@ -215,12 +207,10 @@ mod tests {
         let usage = get_mem_stats(&kind);
         match usage {
             Ok(_) => panic!("Should of returned spork error"),
-            Err(err) => {
-                match err.kind {
-                    SporkErrorKind::Unimplemented => assert!(true),
-                    _ => panic!("Wrong error returnd from child process stats failure")
-                }
-            }
+            Err(err) => match err.kind {
+                SporkErrorKind::Unimplemented => assert!(true),
+                _ => panic!("Wrong error returnd from child process stats failure"),
+            },
         }
     }
 }

--- a/tests/cpu.rs
+++ b/tests/cpu.rs
@@ -1,7 +1,6 @@
-
-extern crate spork;
-extern crate rand;
 extern crate chrono;
+extern crate rand;
+extern crate spork;
 
 #[allow(unused_imports)]
 use spork::{Platform, Spork, SporkError, SporkErrorKind, StatType, Stats};
@@ -16,7 +15,7 @@ use chrono::UTC;
 macro_rules! sleep_ms(
   ($($arg:tt)*) => { {
     thread::sleep(time::Duration::from_millis($($arg)*))
-  } } 
+  } }
 );
 
 fn fib(n: u64) -> u64 {
@@ -130,7 +129,6 @@ fn should_get_linux_thread_stats_fib_35() {
     assert!(stats.polled <= _final as i64);
 }
 
-
 #[test]
 fn should_get_low_cpu_linux_thread_stats() {
     let wait = rand_in_range(4000, 6000);
@@ -225,19 +223,19 @@ fn should_always_have_increasing_cpu_times() {
 
     sleep_ms!(wait);
 
-    let mut prev_times = vec!();
+    let mut prev_times = vec![];
     for _x in 0..10 {
-      let stats = match spork.stats(StatType::Process) {
-          Ok(s) => s,
-          Err(e) => panic!("Stats error {:?}", e),
-      };
-      prev_times.push(stats.cpu_time);
+        let stats = match spork.stats(StatType::Process) {
+            Ok(s) => s,
+            Err(e) => panic!("Stats error {:?}", e),
+        };
+        prev_times.push(stats.cpu_time);
     }
 
     let mut prev_time: f64 = 0_f64;
     for time in &prev_times {
-      assert!(time >= &prev_time);
-      prev_time = *time;
+        assert!(time >= &prev_time);
+        prev_time = *time;
     }
 }
 
@@ -249,19 +247,19 @@ fn should_always_have_increasing_cpus_times() {
 
     sleep_ms!(wait);
 
-    let mut prev_times = vec!();
+    let mut prev_times = vec![];
     for _x in 0..10 {
-      let stats = match spork.stats_with_cpus(StatType::Process, Some(spork.num_cores())) {
-          Ok(s) => s,
-          Err(e) => panic!("Stats error {:?}", e),
-      };
-      prev_times.push(stats.cpu_time);
+        let stats = match spork.stats_with_cpus(StatType::Process, Some(spork.num_cores())) {
+            Ok(s) => s,
+            Err(e) => panic!("Stats error {:?}", e),
+        };
+        prev_times.push(stats.cpu_time);
     }
 
     let mut prev_time: f64 = 0_f64;
     for time in &prev_times {
-      assert!(time >= &prev_time);
-      prev_time = *time;
+        assert!(time >= &prev_time);
+        prev_time = *time;
     }
 }
 

--- a/tests/threads.rs
+++ b/tests/threads.rs
@@ -5,14 +5,14 @@ use spork::{Platform, Spork, SporkError, SporkErrorKind, StatType, Stats};
 
 use std::time;
 
-use std::thread;
-use std::sync::mpsc::{Receiver, Sender};
 use std::sync::mpsc;
+use std::sync::mpsc::{Receiver, Sender};
+use std::thread;
 
 macro_rules! sleep_ms(
   ($($arg:tt)*) => { {
     thread::sleep(time::Duration::from_millis($($arg)*))
-  } } 
+  } }
 );
 
 fn fib(n: u64) -> u64 {
@@ -46,7 +46,6 @@ fn should_correctly_poll_2_threads_separately() {
         };
         tx_expensive.send(stats.cpu).unwrap();
     });
-
 
     let (tx_simple, rx_simple): (Sender<f64>, Receiver<f64>) = mpsc::channel();
     thread::spawn(move || {
@@ -94,7 +93,6 @@ fn should_correctly_poll_10_threads_separately() {
                 };
                 tx_expensive.send(stats.cpu).unwrap();
             });
-
 
             let (tx_simple, rx_simple): (Sender<f64>, Receiver<f64>) = mpsc::channel();
             thread::spawn(move || {


### PR DESCRIPTION
- Fix the problem of compiling with `musl`.
- Fix warnings and `cargo fmt`.