### PR TITLE
[OKTA-558567] fix vulnerable dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,14 +7,14 @@ license = "MIT"
 name = "spork"
 readme = "README.md"
 repository = "https://github.com/azuqua/spork.rs"
-version = "0.1.0"
+version = "0.1.1"
 
 [dependencies]
-chrono = "0.3"
+chrono = "0.4.23"
 kernel32-sys = "0.2"
 libc = "0.2"
 psapi-sys = "0.1"
-sys-info = "0.5.6"
+sys-info = "0.9.1"
 thread-id = "3.0"
 winapi = "0.2"
 
@@ -22,7 +22,7 @@ winapi = "0.2"
 git = "https://github.com/azuqua/mach"
 
 [dev-dependencies]
-rand = "0.3.15"
+rand = "0.8.5"
 
 [features]
 compile_unimplemented = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,6 +154,8 @@ impl From<sys_info::Error> for SporkError {
             }
             sys_info::Error::ExecFailed(e) => SporkError::new(SporkErrorKind::Unknown, e.to_string()),
             sys_info::Error::IO(e) => SporkError::new(SporkErrorKind::Unknown, e.to_string()),
+            sys_info::Error::SystemTime(e) => SporkError::new(SporkErrorKind::Unknown, e.to_string()),
+            sys_info::Error::General(e) => SporkError::new(SporkErrorKind::Unknown, e),
             sys_info::Error::Unknown => {
                 SporkError::new(SporkErrorKind::Unknown, "Sys_info encountered an unknown error.")
             }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,4 @@
-use chrono::UTC;
+use chrono::Utc;
 use sys_info;
 use thread_id;
 
@@ -130,7 +130,7 @@ pub fn calc_duration(kind: &StatType, history: &History, started: i64, polled: i
 }
 
 pub fn now_ms() -> i64 {
-    let now = UTC::now();
+    let now = Utc::now();
     (now.timestamp() * 1000 + (now.timestamp_subsec_millis() as i64)) as i64
 }
 

--- a/tests/cpu.rs
+++ b/tests/cpu.rs
@@ -10,7 +10,7 @@ use std::time;
 
 use self::rand::distributions::{IndependentSample, Range};
 
-use chrono::UTC;
+use chrono::Utc;
 
 macro_rules! sleep_ms(
   ($($arg:tt)*) => { {
@@ -27,7 +27,7 @@ fn fib(n: u64) -> u64 {
 }
 
 fn now_ms() -> i64 {
-    let now = UTC::now();
+    let now = Utc::now();
     (now.timestamp() * 1000 + (now.timestamp_subsec_millis() as i64)) as i64
 }
 


### PR DESCRIPTION
* `sys_info` 0.5.6 -> 0.9.1
* `chrono` 0.3 -> 0.4.23
  * Not vulnerable but `chrono@0.3` is quite outdated so took this opportunity to update it.

[OKTA-558567](https://oktainc.atlassian.net/browse/OKTA-558567). 