### PR TITLE
Various fixes and improvements to spork.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ name = "spork"
 readme = "README.md"
 repository = "https://github.com/azuqua/spork.rs"
 version = "0.1.1"
+edition = "2021"
 
 [dependencies]
 chrono = "0.4.23"
@@ -17,6 +18,7 @@ psapi-sys = "0.1"
 sys-info = "0.9.1"
 thread-id = "3.0"
 winapi = "0.2"
+num_cpus = "1.15"
 
 [dependencies.mach]
 git = "https://github.com/azuqua/mach"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,14 +11,21 @@ version = "0.1.1"
 edition = "2021"
 
 [dependencies]
-chrono = "0.4.23"
-kernel32-sys = "0.2"
+chrono = "0.4"
 libc = "0.2"
-psapi-sys = "0.1"
-sys-info = "0.9.1"
-thread-id = "4.1.0"
-winapi = "0.2"
+sys-info = "0.9"
+thread-id = "4.1"
 num_cpus = "1.15"
+
+
+[target.'cfg(windows)'.dependencies.windows-sys]
+version = "0.48.0"
+features = [
+    "Win32_Foundation",
+    "Win32_System_Threading",
+    "Win32_System_ProcessStatus"
+]
+
 
 [dev-dependencies]
 rand = "0.8.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ kernel32-sys = "0.2"
 libc = "0.2"
 psapi-sys = "0.1"
 sys-info = "0.9.1"
-thread-id = "3.0"
+thread-id = "4.1.0"
 winapi = "0.2"
 num_cpus = "1.15"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ sys-info = "0.9"
 thread-id = "4.1"
 num_cpus = "1.15"
 
-
 [target.'cfg(windows)'.dependencies.windows-sys]
 version = "0.48.0"
 features = [
@@ -26,6 +25,11 @@ features = [
     "Win32_System_ProcessStatus"
 ]
 
+[target.'cfg(all(target_os = "macos", target_arch = "aarch64"))'.dependencies.apple-sys]
+version = "0.2.0"
+features = [
+    "IOKit"
+]
 
 [dev-dependencies]
 rand = "0.8.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ keywords = ["cpu", "memory", "usage"]
 license = "MIT"
 name = "spork"
 readme = "README.md"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,6 @@ thread-id = "3.0"
 winapi = "0.2"
 num_cpus = "1.15"
 
-[dependencies.mach]
-git = "https://github.com/azuqua/mach"
-
 [dev-dependencies]
 rand = "0.8.5"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,10 @@
 [package]
 authors = ["Alec Embke <aembke@gmail.com>"]
 categories = []
-documentation = "http://azuqua.github.io/spork.rs"
 keywords = ["cpu", "memory", "usage"]
 license = "MIT"
 name = "spork"
 readme = "README.md"
-repository = "https://github.com/azuqua/spork.rs"
 version = "0.1.1"
 edition = "2021"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ edition = "2021"
 chrono = "0.4"
 libc = "0.2"
 sys-info = "0.9"
-thread-id = "4.1"
 num_cpus = "1.15"
 
 [target.'cfg(windows)'.dependencies.windows-sys]

--- a/src/darwin.rs
+++ b/src/darwin.rs
@@ -1,20 +1,16 @@
-use mach::task::task_info;
-use mach::task_info::{
-    task_basic_info, task_basic_info_t, task_thread_times_info, task_thread_times_info_t, MIG_ARRAY_TOO_LARGE,
-    TASK_BASIC_INFO, TASK_BASIC_INFO_COUNT, TASK_THREAD_TIMES_INFO, TASK_THREAD_TIMES_INFO_COUNT,
-};
+use std::mem::MaybeUninit;
+use std::time::Duration;
 
-use mach::time_value::{time_value_add, time_value_t};
-
-use mach::traps::mach_task_self;
-
-use mach::kern_return::{KERN_INVALID_ARGUMENT, KERN_SUCCESS};
-
-use libc;
-use libc::rusage;
 use libc::timespec;
 use libc::timeval;
+use libc::{
+    integer_t, kern_return_t, mach_task_basic_info, mach_task_self, rusage, task_thread_times_info, time_value_t,
+    KERN_INVALID_ARGUMENT, KERN_SUCCESS, MACH_TASK_BASIC_INFO, MACH_TASK_BASIC_INFO_COUNT, TASK_THREAD_TIMES_INFO,
+    TASK_THREAD_TIMES_INFO_COUNT,
+};
 use libc::{EFAULT, EINVAL, EPERM, RUSAGE_CHILDREN, RUSAGE_SELF};
+
+pub const MIG_ARRAY_TOO_LARGE: kern_return_t = -307;
 
 use super::*;
 
@@ -54,31 +50,36 @@ fn map_mach_resp(code: libc::c_int) -> Result<i32, SporkError> {
 }
 
 #[allow(dead_code)]
-pub fn merge_thread_times_to_timespec(thread_times: &task_thread_times_info) -> timespec {
-    let mut time_total = time_value_t {
-        seconds: 0,
-        microseconds: 0,
-    };
-    time_value_add(&mut time_total, &(thread_times.user_time));
-    time_value_add(&mut time_total, &(thread_times.system_time));
-    time_value_t_to_timespec(&time_total)
+pub fn merge_thread_times_to_timespec(thread_times: task_thread_times_info) -> timespec {
+    let user_time = Duration::from_micros(thread_times.user_time.microseconds as u64)
+        + Duration::from_secs(thread_times.user_time.seconds as u64);
+
+    let system_time = Duration::from_micros(thread_times.system_time.microseconds as u64)
+        + Duration::from_secs(thread_times.system_time.seconds as u64);
+
+    let total = user_time + system_time;
+
+    time_value_t_to_timespec(time_value_t {
+        seconds: total.as_secs() as integer_t,
+        microseconds: total.subsec_micros() as integer_t,
+    })
 }
 
-pub fn time_value_t_to_timespec(times: &time_value_t) -> timespec {
+pub fn time_value_t_to_timespec(times: time_value_t) -> timespec {
     timespec {
         tv_sec: times.seconds as i64,
         tv_nsec: (times.microseconds * 1000) as i64,
     }
 }
 
-pub fn time_value_t_to_timeval(times: &time_value_t) -> timeval {
+pub fn time_value_t_to_timeval(times: time_value_t) -> timeval {
     timeval {
         tv_sec: times.seconds as i64,
         tv_usec: times.microseconds,
     }
 }
 
-pub fn timespec_to_timeval(times: &timespec) -> timeval {
+pub fn timespec_to_timeval(times: timespec) -> timeval {
     timeval {
         tv_sec: times.tv_sec,
         tv_usec: (times.tv_nsec / 1000) as i32,
@@ -86,35 +87,45 @@ pub fn timespec_to_timeval(times: &timespec) -> timeval {
 }
 
 pub fn get_rusage_from_mach(usage: &mut rusage) -> Result<i32, SporkError> {
-    let mut basic_info = task_basic_info::new();
-    let basic_info_ptr = (&mut basic_info as task_basic_info_t) as libc::uintptr_t;
-    let mut count = TASK_BASIC_INFO_COUNT;
+    let mut count = MACH_TASK_BASIC_INFO_COUNT;
 
-    map_mach_resp(unsafe { task_info(mach_task_self(), TASK_BASIC_INFO, basic_info_ptr, &mut count) })?;
+    let mut basic_info: MaybeUninit<mach_task_basic_info> = MaybeUninit::zeroed();
+    map_mach_resp(unsafe {
+        libc::task_info(
+            mach_task_self(),
+            MACH_TASK_BASIC_INFO,
+            basic_info.as_mut_ptr().cast(),
+            &mut count,
+        )
+    })?;
+
+    let basic_info = unsafe { basic_info.assume_init() };
+
     usage.ru_maxrss = basic_info.resident_size as i64 / 1024;
-    usage.ru_stime = time_value_t_to_timeval(&basic_info.system_time);
+    usage.ru_stime = time_value_t_to_timeval(basic_info.system_time);
 
     Ok(KERN_SUCCESS)
 }
 
 // this should always be called before get_stats since they both consume the clock
 pub fn get_thread_cpu_time() -> Result<timespec, SporkError> {
-    let mut thread_times = task_thread_times_info::new();
-    let thread_times_ptr = (&mut thread_times as task_thread_times_info_t) as libc::uintptr_t;
+    let mut thread_times: MaybeUninit<task_thread_times_info> = MaybeUninit::zeroed();
     let mut thread_times_count = TASK_THREAD_TIMES_INFO_COUNT;
     let _ = map_mach_resp(unsafe {
-        task_info(
+        libc::task_info(
             mach_task_self(),
             TASK_THREAD_TIMES_INFO,
-            thread_times_ptr,
+            thread_times.as_mut_ptr().cast(),
             &mut thread_times_count,
         )
     })?;
 
-    // Appears the Linux equivilent to this actually is a compination of CPU and USER times
+    let thread_times = unsafe { thread_times.assume_init() };
+
+    // Appears the Linux equivalent to this actually is a combination of CPU and USER times
     // Ok(time_value_t_to_timespec(&(thread_times.user_time)))
     // For now lets combine (Which is what clock_gettime appears to do)
-    Ok(merge_thread_times_to_timespec(&thread_times))
+    Ok(merge_thread_times_to_timespec(thread_times))
 }
 
 pub fn get_stats(kind: &StatType) -> Result<rusage, SporkError> {
@@ -124,16 +135,18 @@ pub fn get_stats(kind: &StatType) -> Result<rusage, SporkError> {
         StatType::Thread => (Some(get_thread_cpu_time()?), None),
     };
 
-    let mut usage = unsafe { std::mem::MaybeUninit::zeroed().assume_init() };
+    let mut usage = std::mem::MaybeUninit::zeroed();
     if let Some(r_code) = code {
-        let _ = map_posix_resp(unsafe { libc::getrusage(r_code, &mut usage) })?;
+        let _ = map_posix_resp(unsafe { libc::getrusage(r_code, usage.as_mut_ptr()) })?;
     } else {
-        let _ = get_rusage_from_mach(&mut usage)?;
+        let _ = unsafe { get_rusage_from_mach(usage.assume_init_mut())? };
     }
 
-    if t_times.is_some() {
+    let mut usage = unsafe { usage.assume_init() };
+
+    if let Some(t_times) = t_times {
         // use clock_gettime results for threads
-        usage.ru_utime = timespec_to_timeval(&t_times.unwrap());
+        usage.ru_utime = timespec_to_timeval(t_times);
     }
 
     Ok(usage)

--- a/src/darwin.rs
+++ b/src/darwin.rs
@@ -166,10 +166,10 @@ pub fn get_cpu_time(val: &rusage) -> f64 {
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 pub fn poke_apple_silicon_cpu_freq() -> Result<u32, SporkError> {
     use apple_sys::IOKit::{
-        kCFAllocatorDefault, kCFAllocatorNull, kIOMainPortDefault, kIOMasterPortDefault, Boolean, CFDataGetBytes,
-        CFDataGetLength, CFIndex, CFRange, CFRelease, CFStringBuiltInEncodings_kCFStringEncodingUTF8,
-        CFStringCreateWithBytesNoCopy, IOIteratorNext, IOMasterPort, IOObjectRelease, IORegistryEntryCreateCFProperty,
-        IORegistryEntryGetName, IOServiceGetMatchingServices, IOServiceMatching, MACH_PORT_NULL,
+        kCFAllocatorDefault, kCFAllocatorNull, kIOMainPortDefault, CFDataGetBytes, CFDataGetLength, CFIndex, CFRange,
+        CFRelease, CFStringBuiltInEncodings_kCFStringEncodingUTF8, CFStringCreateWithBytesNoCopy, IOIteratorNext,
+        IOObjectRelease, IORegistryEntryCreateCFProperty, IORegistryEntryGetName, IOServiceGetMatchingServices,
+        IOServiceMatching,
     };
 
     // SAFETY: IOServiceMatching accepts a C string for name.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -272,9 +272,9 @@ impl Spork {
     pub fn new() -> Result<Spork, SporkError> {
         Ok(Spork {
             history: History::default(),
-            platform: utils::get_platform()?,
+            platform: utils::get_platform(),
             clock: utils::get_cpu_speed()?,
-            cpus: utils::get_num_cores()?,
+            cpus: utils::get_num_cores(),
             started: utils::now_ms(),
         })
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,7 @@ pub type CLong = i64;
 
 mod utils;
 
+use std::fmt::{Display, Formatter};
 use utils::History;
 
 use std::io::Error as IoError;
@@ -93,6 +94,12 @@ pub struct SporkError {
     kind: SporkErrorKind,
 }
 
+impl Display for SporkError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_fmt(format_args!("{}: {}", &self.desc, &self.details))
+    }
+}
+
 impl SporkError {
     /// Create a new SporkError instance
     pub fn new<T: Into<String>>(kind: SporkErrorKind, details: T) -> SporkError {
@@ -117,11 +124,6 @@ impl SporkError {
     /// Read the error's kind
     pub fn kind(&self) -> &SporkErrorKind {
         &self.kind
-    }
-
-    /// Read a formatted string consisting of error desc and details
-    pub fn to_string(&self) -> String {
-        format!("{}: {}", &self.desc, &self.details)
     }
 
     /// Create a new `Error` instance from a borrowed str.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,9 +57,6 @@ pub type CLong = i32;
 #[cfg(target_pointer_width = "64")]
 pub type CLong = i64;
 
-#[cfg(target_os = "macos")]
-extern crate mach;
-
 extern crate chrono;
 extern crate kernel32;
 extern crate libc;
@@ -114,9 +111,9 @@ impl SporkError {
         };
 
         SporkError {
-            desc: desc,
+            desc,
             details: details.into(),
-            kind: kind,
+            kind,
         }
     }
 
@@ -222,7 +219,7 @@ pub struct Stats {
 impl Stats {
     pub fn new_empty(kind: StatType) -> Stats {
         Stats {
-            kind: kind,
+            kind,
             polled: 0,
             duration: 0,
             cpu_time: 0_f64,
@@ -333,8 +330,8 @@ impl Spork {
         let stats = Stats {
             kind: kind.clone(),
             polled: now,
-            duration: duration,
-            cpu_time: cpu_time,
+            duration,
+            cpu_time,
             cpu: cpu_percent,
             memory: (usage.ru_maxrss as u64) * 1000,
             uptime: utils::safe_unsigned_sub(now, self.started),
@@ -433,12 +430,12 @@ impl Spork {
         let stats = Stats {
             kind: kind.clone(),
             polled: now,
-            duration: duration,
-            cpu_time: cpu_time,
+            duration,
+            cpu_time,
             cpu: cpu_percent,
             memory: (usage.ru_maxrss as u64) * 1000,
             uptime: utils::safe_unsigned_sub(now, self.started),
-            cores: cores,
+            cores,
         };
 
         self.history.set_last(&kind, stats.clone());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,14 +57,6 @@ pub type CLong = i32;
 #[cfg(target_pointer_width = "64")]
 pub type CLong = i64;
 
-extern crate chrono;
-extern crate kernel32;
-extern crate libc;
-extern crate psapi;
-extern crate sys_info;
-extern crate thread_id;
-extern crate winapi;
-
 mod utils;
 
 use utils::History;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -132,6 +132,7 @@ pub fn now_ms() -> i64 {
     now.timestamp() * 1000 + (now.timestamp_subsec_millis() as i64)
 }
 
+#[allow(unreachable_code)]
 pub const fn get_platform() -> Platform {
     #[cfg(target_os = "linux")]
     return Platform::Linux;
@@ -142,8 +143,7 @@ pub const fn get_platform() -> Platform {
     #[cfg(target_os = "macos")]
     return Platform::MacOS;
 
-    #[allow(unreachable_code)]
-    return Platform::Unknown;
+    Platform::Unknown
 }
 
 pub fn calc_cpu_percent(history: &History, kind: &StatType, curr_cpu_time: f64, duration: u64) -> f64 {
@@ -155,16 +155,17 @@ pub fn calc_cpu_percent(history: &History, kind: &StatType, curr_cpu_time: f64, 
     ((cpu_time_delta / duration as f64) * 1000_f64) * 100_f64
 }
 
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 pub fn get_cpu_speed() -> Result<u64, SporkError> {
-    if cfg!(all(target_os = "macos", target_arch = "aarch64")) {
-        // hardcoded to 2.4Ghz on M1 machines
-        // see  sysctl hw.tbfrequency
-        Ok(24000000)
-    } else {
-        match sys_info::cpu_speed() {
-            Ok(s) => Ok(s * 1000),
-            Err(e) => Err(SporkError::from(e)),
-        }
+    return Ok(darwin::poke_apple_silicon_cpu_freq()? as u64);
+}
+
+#[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
+pub fn get_cpu_speed() -> Result<u64, SporkError> {
+    match sys_info::cpu_speed() {
+        Ok(s) => Ok(s * 1000),
+        Err(e) => Err(SporkError::from(e)),
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -6,11 +6,12 @@ use std::borrow::BorrowMut;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::ops::{Deref, DerefMut};
+use std::thread::ThreadId;
 
 use super::*;
 
-pub fn get_thread_id() -> usize {
-    thread_id::get()
+pub fn get_thread_id() -> ThreadId {
+    std::thread::current().id()
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -23,9 +24,9 @@ pub struct CpuTime {
 pub struct History {
     process: RefCell<Option<Stats>>,
     // maps thread_id's to the last polled stats
-    thread: RefCell<HashMap<usize, Stats>>,
+    thread: RefCell<HashMap<ThreadId, Stats>>,
     // maps thread_id's to the last polled stats
-    children: RefCell<HashMap<usize, Stats>>,
+    children: RefCell<HashMap<ThreadId, Stats>>,
 }
 
 impl Default for History {
@@ -183,13 +184,6 @@ pub fn empty_timespec() -> timespec {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn should_get_thread_id() {
-        let id = get_thread_id();
-        // FIXME make this smarter
-        assert!(id > 0);
-    }
 
     #[test]
     #[cfg(target_os = "linux")]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -158,11 +158,16 @@ pub fn calc_cpu_percent(history: &History, kind: &StatType, curr_cpu_time: f64, 
 }
 
 pub fn get_cpu_speed() -> Result<u64, SporkError> {
-    Ok(0)
-    // match sys_info::cpu_speed() {
-    //     Ok(s) => Ok(s * 1000),
-    //     Err(e) => Err(SporkError::from(e)),
-    // }
+    if cfg!(all(target_os = "macos", target_arch="aarch64")) {
+        // hardcoded to 2.4Ghz on M1 machines
+        // see  sysctl hw.tbfrequency
+        Ok(24000000)
+    } else {
+        match sys_info::cpu_speed() {
+            Ok(s) => Ok(s * 1000),
+            Err(e) => Err(SporkError::from(e)),
+        }
+    }
 }
 
 pub fn get_num_cores() -> usize {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,4 @@
 use chrono::Utc;
-use sys_info;
-use thread_id;
 
 use libc::timespec;
 
@@ -131,7 +129,7 @@ pub fn calc_duration(kind: &StatType, history: &History, started: i64, polled: i
 
 pub fn now_ms() -> i64 {
     let now = Utc::now();
-    (now.timestamp() * 1000 + (now.timestamp_subsec_millis() as i64)) as i64
+    now.timestamp() * 1000 + (now.timestamp_subsec_millis() as i64)
 }
 
 pub const fn get_platform() -> Platform {
@@ -154,11 +152,11 @@ pub fn calc_cpu_percent(history: &History, kind: &StatType, curr_cpu_time: f64, 
         None => 0_f64,
     };
     let cpu_time_delta = curr_cpu_time - prev_cpu_time;
-    ((cpu_time_delta / duration as f64) * 1000 as f64) * 100 as f64
+    ((cpu_time_delta / duration as f64) * 1000_f64) * 100_f64
 }
 
 pub fn get_cpu_speed() -> Result<u64, SporkError> {
-    if cfg!(all(target_os = "macos", target_arch="aarch64")) {
+    if cfg!(all(target_os = "macos", target_arch = "aarch64")) {
         // hardcoded to 2.4Ghz on M1 machines
         // see  sysctl hw.tbfrequency
         Ok(24000000)
@@ -219,8 +217,7 @@ mod tests {
 
     #[test]
     fn should_get_cpu_speed() {
-        let speed = get_cpu_speed()
-            .unwrap();
+        let speed = get_cpu_speed().unwrap();
 
         assert!(speed > 0);
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -155,7 +155,6 @@ pub fn calc_cpu_percent(history: &History, kind: &StatType, curr_cpu_time: f64, 
     ((cpu_time_delta / duration as f64) * 1000_f64) * 100_f64
 }
 
-
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 pub fn get_cpu_speed() -> Result<u64, SporkError> {
     return Ok(darwin::poke_apple_silicon_cpu_freq()? as u64);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -170,7 +170,7 @@ pub fn get_cpu_speed() -> Result<u64, SporkError> {
 }
 
 pub fn get_num_cores() -> usize {
-    num_cpus::get_physical()
+    num_cpus::get()
 }
 
 // Not actually dead - but cargo thinks it is (Used in tests)

--- a/tests/cpu.rs
+++ b/tests/cpu.rs
@@ -1,6 +1,4 @@
-extern crate chrono;
-extern crate rand;
-extern crate spork;
+
 
 #[allow(unused_imports)]
 use spork::{Platform, Spork, SporkError, SporkErrorKind, StatType, Stats};
@@ -8,9 +6,8 @@ use spork::{Platform, Spork, SporkError, SporkErrorKind, StatType, Stats};
 use std::thread;
 use std::time;
 
-use self::rand::distributions::{IndependentSample, Range};
-
 use chrono::Utc;
+use rand::Rng;
 
 macro_rules! sleep_ms(
   ($($arg:tt)*) => { {
@@ -32,9 +29,8 @@ fn now_ms() -> i64 {
 }
 
 fn rand_in_range(l: u64, r: u64) -> u64 {
-    let between = Range::new(l, r);
     let mut rng = rand::thread_rng();
-    between.ind_sample(&mut rng)
+    rng.gen_range(l..r)
 }
 
 #[test]

--- a/tests/cpu.rs
+++ b/tests/cpu.rs
@@ -1,5 +1,3 @@
-
-
 #[allow(unused_imports)]
 use spork::{Platform, Spork, SporkError, SporkErrorKind, StatType, Stats};
 
@@ -25,7 +23,7 @@ fn fib(n: u64) -> u64 {
 
 fn now_ms() -> i64 {
     let now = Utc::now();
-    (now.timestamp() * 1000 + (now.timestamp_subsec_millis() as i64)) as i64
+    now.timestamp() * 1000 + (now.timestamp_subsec_millis() as i64)
 }
 
 fn rand_in_range(l: u64, r: u64) -> u64 {

--- a/tests/memory.rs
+++ b/tests/memory.rs
@@ -43,7 +43,7 @@ fn should_poll_increased_memory_process() {
 
     while n < 1000000 {
         v.push(255);
-        n = n + 1;
+        n += 1;
     }
 
     let stats = match spork.stats(StatType::Process) {


### PR DESCRIPTION
## General refactoring fixes
* Removes `thread-id` dependency in favour of `std::thread::ThreadId`
* Removes `winapi` in favour of using `windows`
* Removes `mach` in favour of using `libc` 
  * Allows `mach` to be archived and no longer maintained by us ([OKTA-619883](https://oktainc.atlassian.net/browse/OKTA-619883))
* Removes references to `azuqua` repo ([OKTA-619921](https://oktainc.atlassian.net/browse/OKTA-619921))
* Fixes test which uses old `rand` API
* clippy fixes

## [OKTA-626982](https://oktainc.atlassian.net/browse/OKTA-626982) Fixes for better support on Apple Silicon
* Use `num-cpu` to get number of CPUs over sys-info, which does not support M1
* Poke IOReg to get CPU frequency on Apple Silicon since the `hw.cpufrequency` syscall does not work and returns 0
 
## Testing details
* `cargo test` on 
  * M1 MacBook Pro
  * Intel MacBook Pro
  * k8sdbg debug pod
    * The only changes that affect Linux are using `num-cpu` which uses the same techniques as `sys-info`, and removing the invalid usage of `MaybeUninit`. 
  
## Tickets addressed
* [OKTA-619921](https://oktainc.atlassian.net/browse/OKTA-619921) 
* [OKTA-626982](https://oktainc.atlassian.net/browse/OKTA-626982) 
* [OKTA-619883](https://oktainc.atlassian.net/browse/OKTA-619883)